### PR TITLE
sneakyLogin으로 인한 이메일 중복 해결

### DIFF
--- a/src/main/java/com/example/noticebespring/service/auth/social/user/AbstractUserInfoService.java
+++ b/src/main/java/com/example/noticebespring/service/auth/social/user/AbstractUserInfoService.java
@@ -67,7 +67,23 @@ public abstract class AbstractUserInfoService implements SocialUserInfoService {
 
             }
 
-            //2. 신규 사용자일 경우 -> 새로운 소셜 계정 생성 및 회원가입 처리
+            // 2. 이메일로 기존 사용자 있는지 확인
+            Optional<User> existingUserByEmail = userRepository.findByEmail(email);
+            if (existingUserByEmail.isPresent()) {
+                User existingUser = existingUserByEmail.get();
+                logger.info("이메일 중복으로 기존 유저에 소셜 계정 추가 - email: {}, userId: {}", email, existingUser.getId());
+
+                SocialAccount socialAccount = SocialAccount.builder()
+                        .user(existingUser)
+                        .provider(getProviderType())
+                        .providerId(providerId)
+                        .build();
+                socialAccountRepository.save(socialAccount);
+
+                return existingUser;
+            }
+
+            //3. 신규 사용자일 경우 -> 새로운 소셜 계정 생성 및 회원가입 처리
             User user = User.builder()
                     .email(email)
                     .createdAt(LocalDateTime.now())


### PR DESCRIPTION
sneakyLogin에서 등록된 이메일과 사용자 정보 등록할 때의 이메일 중복 에러 해결
-> 기존에 이메일이 존재하면 그 이메일과 소셜계졍을 연결